### PR TITLE
Use gcc package on linux.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,10 @@ source:
 build:
   number: 0
 
+requirements:
+  build:
+    - gcc  # [linux]
+
 test:
   commands:
     - perl --help


### PR DESCRIPTION
In the effort to come up with a common build environment, as far as we know, bioconda and conda-forge agreed to use the gcc package for building stuff on linux. This PR adds gcc to the build requirements for perl, which is used heavily by bioconda packages. The current way of building this with the system gcc on conda-forge/linux-anvil causes problems because it is a different version with different features than the gcc package that is used to build perl packages on bioconda.

@jerowe, @nsoranzo, @bgruening