### PR TITLE
Compile with -fPIC

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,7 +10,7 @@ if [ `uname -s` == "Darwin" ]; then
     export LDFLAGS="${LDFLAGS} -Wl,-headerpad_max_install_names"
 fi
 
-sh Configure -Dusethreads -Duserelocatableinc -Dprefix=$PREFIX -de -Aldflags="$LDFLAGS"
+sh Configure -Dusethreads -Duserelocatableinc -Dprefix=$PREFIX -de -Aldflags="$LDFLAGS" -Accflags=-fPIC
 make
 
 # change permissions again after building


### PR DESCRIPTION
This will allow other recipes to compile shared objects with `gcc -lperl`, which currently fail with the error:
```
relocation R_X86_64_PC32 against symbol `PL_opargs' can not be used when making a shared object; recompile with -fPIC
```