### PR TITLE
fix sed @-escaping command

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -54,15 +54,14 @@ make install
 
 # Replace hard-coded BUILD_PREFIX by value from env as CC, CFLAGS etc need to be properly set to be usable by ExtUtils::MakeMaker module
 (cd $PREFIX/lib/5*/*-thread-*/ && patch -p1) < $RECIPE_DIR/dynamic_config.patch
-sed -i.bak "s|conda@|conda\\\@|g" $PREFIX/lib/*/*/Config_heavy.pl
+sed -i.bak "s|\\(='[^'\\@]*\\)@|\\1\\\\@|g" $PREFIX/lib/*/*/Config_heavy.pl
 sed -i.bak "s|${BUILD_PREFIX}|\$compilerroot|g" $PREFIX/lib/*/*/Config_heavy.pl
 
 sed -i.bak "s|cc => '\(.*\)'|cc => \"\1\"|g" $PREFIX/lib/*/*/Config.pm
 sed -i.bak "s|libpth => '\(.*\)'|libpth => \"\1\"|g" $PREFIX/lib/*/*/Config.pm
 sed -i.bak "s|${BUILD_PREFIX}|\$compilerroot|g" $PREFIX/lib/*/*/Config.pm
 
-# 3 more seds for osx:
-sed -i.bak "s|vsts@|vsts\\\@|g" $PREFIX/lib/*/*/Config_heavy.pl
+# 2 more seds for osx:
 sed -i.bak "s|\\\c|\\\\\\\c|g" $PREFIX/lib/*/*/Config_heavy.pl
 sed -i.bak "s|DPERL_SBRK_VIA_MALLOC \$ccflags|DPERL_SBRK_VIA_MALLOC \\\\\$ccflags|g" $PREFIX/lib/*/*/Config_heavy.pl
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
   sha1: c4211d4651620506412f757ea221ee6088f2ed91                                                                  # [win32]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Previously we had
```
lib/5.26.2/x86_64-linux-thread-multi/Config_heavy.pl:249:cf_email='conda\@5b5b05c2e5c2.(none)'
lib/5.26.2/x86_64-linux-thread-multi/Config_heavy.pl:1178:perladmin='conda\@5b5b05c2e5c2.(none)'
lib/5.26.2/darwin-thread-multi-2level/Config_heavy.pl:251:cf_email='vsts\@mac-616.local'
lib/5.26.2/darwin-thread-multi-2level/Config_heavy.pl:1182:perladmin='vsts\@mac-616.local'
```
now it is
```
lib/5.30.3/x86_64-linux-thread-multi/Config_heavy.pl:248:cf_email='conda\@f52d8439f892.(none)'
lib/5.30.3/x86_64-linux-thread-multi/Config_heavy.pl:1173:perladmin='conda\@f52d8439f892.(none)'
lib/5.30.3/darwin-thread-multi-2level/Config_heavy.pl:250:cf_email='root@mac-1610.local'
lib/5.30.3/darwin-thread-multi-2level/Config_heavy.pl:1177:perladmin='root@mac-1610.local'
```
. Which means the osx build is currently broken.

It would be good to add a test for this, but I don't know Perl, so can't easily help with that.