### PR TITLE
mark 5.26.2 as branch that gets ABI migrations

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,3 +2,6 @@ build_platform: {osx_arm64: osx_64}
 conda_forge_output_validation: true
 provider: {linux_aarch64: default, linux_ppc64le: default}
 test_on_native_only: true
+bot: 
+  abi_migration_branches:
+    - 5.26.2


### PR DESCRIPTION
This way it gets migrations like rebuilds for different chips and the like

cc: @beckermr @xhochy